### PR TITLE
Updated instances of old Grizzle_e to grizzl-e

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,22 @@
 
 A Home Assistant integration for Grizzl-E EVSEs (Electric Vehicle Supply Equipment, or charger), providing sensors for monitoring the WiFi Grizzl-E EVSEs.
 
-This integration works with most WiFi enabled Grizzl-E chargers (the Connect and Ultimate lines) but does not work with chargers enrolled in the "Grizzl-E Club" or comercial chargers.
+This integration works with most WiFi enabled Grizzl-E chargers (the Connect and Ultimate lines) but does not work with chargers enrolled in the "Grizzl-E Club" or commercial chargers.
 
-This integration is not affiliated with United s or Grizzl-E (but is also made in Ontario, Canada). Please consult [United 's User Manuals](https://grizzl-e.com/user-manuals) can learn more about operating Grizzl-E EVSE.
+This integration is not affiliated with United Chargers or Grizzl-E (but is also made in Ontario, Canada). Please consult [United Chargers' User Manuals](https://grizzl-e.com/user-manuals) to learn more about operating Grizzl-E EVSEs.
 
 
 
 ## ⚠️ Security Note
 Did you know that your United Chargers Grizzl-E WiFi enabled EVSE has a web interface that is by default unauthenticated? If you haven't visited the Grizzl-E web interface, referred to in the user manuals as [Page Access](https://ecommerce-space.nyc3.digitaloceanspaces.com/Operation_Manual_V4_0_d5c730c075.pdf#Grizzl-EUltimate_OperationManual_V4.0.indd%3AAnchor%203%3A3092), and set a password, you should do that right away. This integration assumes a username and password has been set.
 
-Even once a username and password is set, users should ensure that thier EVSE is properly secured on their network from the rest of the internet.
+Even once a username and password is set, users should ensure that their EVSE is properly secured on their network from the rest of the internet.
 
 ## Features
 
 This integration provides the following features:
 - Real-time monitoring of charging status and metrics
-- Support for multiple Grizzl-E  models
+- Support for multiple Grizzl-E models
 - Configurable polling interval
 - Temperature monitoring
 - Energy usage tracking
@@ -37,21 +37,21 @@ This integration provides the following features:
 5. Add this repository URL: `https://github.com/mclare/grizzl_e-for-HA`
 6. Select category: "Integration"
 7. Click "Add"
-8. Find "Grizzl-E EV " in the list and click "Install"
+8. Find "Grizzl-E EV" in the list and click "Install"
 9. Restart Home Assistant
 10. Go to Settings > Devices & Services
-11. Click "+ Add Integration" and search for "Grizzl-E EV "
-12. Follow the setup wizard to configure your 
+11. Click "+ Add Integration" and search for "Grizzl-E EV"
+12. Follow the setup wizard
 
 ### Manual Installation
 
 1. Download the latest release from the [Releases](https://github.com/mclare/grizzl_e-for-HA/releases) page
-2. Extract the `grizzle_e` folder from the archive
-3. Copy the `grizzle_e` folder to your `custom_components` directory in your Home Assistant config
+2. Extract the `grizzl-e` folder from the archive
+3. Copy the `grizzl-e` folder to your `custom_components` directory in your Home Assistant config
 4. Restart Home Assistant
 5. Go to Settings > Devices & Services
-6. Click "+ Add Integration" and search for "Grizzl-E EV "
-7. Follow the setup wizard to configure your 
+6. Click "+ Add Integration" and search for "Grizzl-E EV"
+7. Follow the setup wizard
 
 ## Configuration
 
@@ -59,15 +59,15 @@ This integration provides the following features:
 
 1. Go to Settings > Devices & Services
 2. Click "+ Add Integration"
-3. Search for "Grizzl-E EV "
-4. Enter your 's IP address or hostname
+3. Search for "Grizzl-E EV"
+4. Enter the IP address or hostname of your EVSE
 5. Enter the username and password (default is usually admin/admin)
 
 ### Configuration via YAML
 
 ```yaml
 # Example configuration.yaml entry
-grizzle_e:
+grizzl-e:
   host: YOUR_EVSE_IP_ADDRESS
   username: admin
   password: yourpassword
@@ -100,7 +100,7 @@ You will need:
 - The **IP address** of your Grizzl-E EVSE
 - The **username**
 - The **password**
-- Your computer and EVSE on the **same network** or the firewall rules to allow access
+- Home Assistant and EVSE on the **same network** or the firewall rules to allow access
 
 ---
 
@@ -108,7 +108,7 @@ You will need:
 
 #### Step 1: Verify Web Interface Access
 
-Verify that you can access the Grizzl-E EVSE's web interface with your regular web browser. The bottom of the page will show the EVSE Version, WiFi Version and Serial Number.
+Verify that you can access the Grizzl-E EVSE's web interface with your regular web browser. The bottom of the page will show the EVSE Version, WiFi Version, and Serial Number.
 
 
 #### Step 2, option 1: Command line (macOS and Linux)

--- a/custom_components/grizzl-e/const.py
+++ b/custom_components/grizzl-e/const.py
@@ -1,7 +1,7 @@
 """Constants for the Grizzl-E integration."""
 
 # Integration domain
-DOMAIN = "grizzle_e"
+DOMAIN = "grizzl-e"
 DEFAULT_NAME = "Grizzl-E Charger"
 MANUFACTURER = "United Chargers"
 MODEL = "Grizzl-E Smart"


### PR DESCRIPTION
There were still some leftovers of the old integration name in the const.py file which would cause the integration to fail with the error `Config flow could not be loaded: {"message":"Invalid handler specified"}` when trying to add it from the GUI.

I also corrected some typo and wording issues in the README file.