### PR TITLE
Update domain from grizzl-e to grizzl_e

### DIFF
--- a/custom_components/grizzl-e/manifest.json
+++ b/custom_components/grizzl-e/manifest.json
@@ -1,5 +1,5 @@
 {
-  "domain": "grizzl-e",
+  "domain": "grizzl_e",
   "name": "Grizzl-E EV Charger",
   "version": "0.2.0",
   "documentation": "https://github.com/mclare/grizzl_e-for-HA",


### PR DESCRIPTION
Somewhere along the way the - wasn't permitted.