### PR TITLE
Fix Grizzl-E Duo port 2 current/voltage/power reporting (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v1.6
+- **Fix Grizzl-E Duo port 2 reporting** ([#23](https://github.com/mclare/grizzl_e-for-HA/issues/23)). The Duo does not report its second cable through `curMeas2`/`voltMeas2` (those are per-phase fields that stay `0`). Cable 2 now reads current from `curMeas1C2`, voltage from the shared `voltMeas1`, and power from `powerMeas2`.
+    - Added a `port_key()` mapping helper in `const.py` that resolves each per-cable measurement to the correct JSON key for a given port.
+    - Multi-port units now expose Power, Current, Voltage, Session Energy, Total Energy, Session Time, Session Money, State and Pilot State **per cable** (previously only Current/Voltage were per-port and everything else was cable-1 only). Binary sensors (Session Started, Pilot Connected) are now per cable too.
+    - Port 1 keeps its original entity `unique_id`s, so existing single-port setups keep their history. Port 2+ get disambiguated ids.
+    - Enum sensors (State, Pilot State) no longer carry an invalid `measurement` state class.
+    - Added regression tests using the real Duo payloads from issue #23.
+
 ## v1.0
 - First full release!
 - **Breaking changes from pre-release versions**: the domain has changed from `grizzl-e` to `grizzl_e` to match some of the restricted namespaces across Home Assistant/HACS. This will require a reinstallation of the integration.

--- a/custom_components/grizzl_e/binary_sensor.py
+++ b/custom_components/grizzl_e/binary_sensor.py
@@ -3,7 +3,7 @@ from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, DEFAULT_NAME
+from .const import DOMAIN, DEFAULT_NAME, CONF_PORTS, port_key
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,10 +18,17 @@ async def async_setup_entry(hass, entry, async_add_entities):
     # Set device info on coordinator for binary sensors to access
     coordinator.device = device
 
-    binaries = [
-        GrizzleEBinarySensor(coordinator, "Session Started", "sessionStarted"),
-        GrizzleEBinarySensor(coordinator, "Pilot Connected", "pilot"),
-    ]
+    num_ports = entry.data.get(CONF_PORTS, 1)
+
+    binaries = []
+    for port in range(1, num_ports + 1):
+        port_suffix = f" Port {port}" if num_ports > 1 else ""
+        for name, field in (("Session Started", "session_started"), ("Pilot Connected", "pilot")):
+            key = port_key(field, port)
+            unique_key = key if port <= 1 else f"{key}_p{port}"
+            binaries.append(
+                GrizzleEBinarySensor(coordinator, f"{name}{port_suffix}", key, unique_key=unique_key)
+            )
 
     async_add_entities(binaries)
 
@@ -36,11 +43,11 @@ class GrizzleEBinarySensor(CoordinatorEntity, BinarySensorEntity):
         """Return the device info."""
         return self.coordinator.device.device_info
 
-    def __init__(self, coordinator, name, key):
+    def __init__(self, coordinator, name, key, unique_key=None):
         super().__init__(coordinator)
         self._attr_name = name
         self._key = key
-        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}_{key}"
+        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}_{unique_key or key}"
 
     @property
     def is_on(self):

--- a/custom_components/grizzl_e/const.py
+++ b/custom_components/grizzl_e/const.py
@@ -25,3 +25,44 @@ DEFAULT_SCAN_INTERVAL = 5
 REQUEST_TIMEOUT = 10  # Total request timeout
 CONNECT_TIMEOUT = 5   # Connection timeout
 SOCKET_TIMEOUT = 5    # Socket read timeout
+
+# Mapping of logical per-cable measurements to the /main JSON keys used by
+# port/cable 1. See port_key() for how the keys for port 2+ are derived.
+PORT_FIELD_KEYS = {
+    "current": "curMeas1",
+    "voltage": "voltMeas1",
+    "power": "powerMeas",
+    "state": "state",
+    "pilot": "pilot",
+    "session_time": "sessionTime",
+    "session_energy": "sessionEnergy",
+    "session_money": "sessionMoney",
+    "total_energy": "totalEnergy",
+    "session_started": "sessionStarted",
+}
+
+
+def port_key(field: str, port: int) -> str:
+    """Return the /main JSON key for a logical per-cable field on a port.
+
+    The Grizzl-E Duo does not report cable 2 through the naive
+    ``curMeas2``/``voltMeas2`` fields (those are per-phase measurements and
+    stay ``0`` on a single-phase Duo). Instead the second cable's data is
+    reported through a mix of fields (see issue #23):
+
+      * current       -> ``curMeas1C2``   (``curMeas1C3`` for a 3rd cable)
+      * voltage       -> ``voltMeas1``    (both cables share one circuit, so
+                                           voltage is only reported once)
+      * everything else -> the port-1 key with the port number appended,
+                           e.g. ``powerMeas2``, ``state2``, ``pilot2``,
+                           ``sessionTime2`` ...
+    """
+    base = PORT_FIELD_KEYS[field]
+    if port <= 1:
+        return base
+    if field == "voltage":
+        # Both cables share a single circuit; voltage is only reported once.
+        return PORT_FIELD_KEYS["voltage"]
+    if field == "current":
+        return f"curMeas1C{port}"
+    return f"{base}{port}"

--- a/custom_components/grizzl_e/manifest.json
+++ b/custom_components/grizzl_e/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mclare/grizzl_e-for-HA/issues",
   "requirements": [],
-  "version": "1.5"
+  "version": "1.6"
 }

--- a/custom_components/grizzl_e/sensor.py
+++ b/custom_components/grizzl_e/sensor.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import EntityCategory, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, CONF_PORTS
+from .const import DOMAIN, CONF_PORTS, port_key
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,49 +38,43 @@ async def async_setup_entry(hass, entry, async_add_entities):
     # Ensure we have fresh data
     await coordinator.async_config_entry_first_refresh()
     
-    # Base sensors (not port-specific)
+    # Device-wide sensors (not tied to a specific charging cable).
     sensors = [
-        GrizzleESensor(coordinator, "Power", "powerMeas", UnitOfPower.WATT, device_class=SensorDeviceClass.POWER),
-        GrizzleESensor(coordinator, "Session Energy", "sessionEnergy", UnitOfEnergy.KILO_WATT_HOUR, device_class=SensorDeviceClass.ENERGY),
-        GrizzleESensor(coordinator, "Total Energy", "totalEnergy", UnitOfEnergy.KILO_WATT_HOUR, device_class=SensorDeviceClass.ENERGY, state_class=SensorStateClass.TOTAL_INCREASING),
         GrizzleESensor(coordinator, "Temperature 1", "temperature1", UnitOfTemperature.CELSIUS, device_class=SensorDeviceClass.TEMPERATURE),
         GrizzleESensor(coordinator, "Temperature 2", "temperature2", UnitOfTemperature.CELSIUS, device_class=SensorDeviceClass.TEMPERATURE),
         GrizzleESensor(coordinator, "RSSI", "RSSI", "dBm", device_class=SensorDeviceClass.SIGNAL_STRENGTH, entity_category=EntityCategory.DIAGNOSTIC),
-        GrizzleESensor(coordinator, "State", "state", None, device_class=SensorDeviceClass.ENUM, options=["PowerUp", "SelfTest", "Standby", "Vehicle Connected", "Vehile Charging","Charing Complete","Disabled","Error"]),
-        GrizzleESensor(coordinator, "Pilot State", "pilot", None, device_class=SensorDeviceClass.ENUM, options=["no_ev", "ev_connected"]),
-        GrizzleESensor(coordinator, "Session Time", "sessionTime", UnitOfTime.SECONDS, device_class=SensorDeviceClass.DURATION),
-        GrizzleESensor(coordinator, "Session Money", "sessionMoney", CURRENCY_DOLLAR, device_class=SensorDeviceClass.MONETARY),
         # Diagnostic and version information
         GrizzleESensor(coordinator, "EVSE Version", "verFWMain", None, entity_category=EntityCategory.DIAGNOSTIC, state_class=None),
         GrizzleESensor(coordinator, "WiFi Version", "verFWWifi", None, entity_category=EntityCategory.DIAGNOSTIC, state_class=None),
     ]
 
-    # Add port-specific sensors
+    # Per-cable/port sensors. On multi-cable units (e.g. the Grizzl-E Duo) the
+    # second cable reports through a different set of JSON keys, resolved by
+    # port_key(); see const.py and issue #23.
+    state_options = ["PowerUp", "SelfTest", "Standby", "Vehicle Connected", "Vehile Charging", "Charing Complete", "Disabled", "Error"]
+
     for port in range(1, num_ports + 1):
         port_suffix = f" Port {port}" if num_ports > 1 else ""
-        
-        # Always add current and voltage sensors, they'll handle None values
-        current_key = f"curMeas{port}"
-        sensors.append(
-            GrizzleESensor(
-                coordinator,
-                f"Current{port_suffix}",
-                current_key,
-                UnitOfElectricCurrent.AMPERE,
-                device_class=SensorDeviceClass.CURRENT
+
+        def add(field, name, unit, **kwargs):
+            key = port_key(field, port)
+            # Preserve the original (single-port) unique_ids for port 1 so
+            # existing entities/history are kept; disambiguate port 2+ since
+            # some fields (e.g. voltage) are shared across cables.
+            unique_key = key if port <= 1 else f"{key}_p{port}"
+            sensors.append(
+                GrizzleESensor(coordinator, f"{name}{port_suffix}", key, unit, unique_key=unique_key, **kwargs)
             )
-        )
-        
-        voltage_key = f"voltMeas{port}"
-        sensors.append(
-            GrizzleESensor(
-                    coordinator,
-                    f"Voltage{port_suffix}",
-                    voltage_key,
-                    UnitOfElectricPotential.VOLT,
-                    device_class=SensorDeviceClass.VOLTAGE
-                )
-            )
+
+        add("power", "Power", UnitOfPower.WATT, device_class=SensorDeviceClass.POWER)
+        add("current", "Current", UnitOfElectricCurrent.AMPERE, device_class=SensorDeviceClass.CURRENT)
+        add("voltage", "Voltage", UnitOfElectricPotential.VOLT, device_class=SensorDeviceClass.VOLTAGE)
+        add("session_energy", "Session Energy", UnitOfEnergy.KILO_WATT_HOUR, device_class=SensorDeviceClass.ENERGY)
+        add("total_energy", "Total Energy", UnitOfEnergy.KILO_WATT_HOUR, device_class=SensorDeviceClass.ENERGY, state_class=SensorStateClass.TOTAL_INCREASING)
+        add("session_time", "Session Time", UnitOfTime.SECONDS, device_class=SensorDeviceClass.DURATION)
+        add("session_money", "Session Money", CURRENCY_DOLLAR, device_class=SensorDeviceClass.MONETARY)
+        add("state", "State", None, device_class=SensorDeviceClass.ENUM, state_class=None, options=state_options)
+        add("pilot", "Pilot State", None, device_class=SensorDeviceClass.ENUM, state_class=None, options=["no_ev", "ev_connected"])
 
     async_add_entities(sensors)
 
@@ -105,6 +99,7 @@ class GrizzleESensor(CoordinatorEntity, SensorEntity):
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=None,
         options=None,
+        unique_key=None,
     ):
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -116,10 +111,13 @@ class GrizzleESensor(CoordinatorEntity, SensorEntity):
         self._attr_entity_category = entity_category
         if options:
             self._attr_options = options
-            
+
         # Set device info
         self._attr_has_entity_name = True  # Use device name as prefix
-        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}_{key}"
+        # ``unique_key`` lets several sensors share the same JSON key (e.g.
+        # both cables read voltage from ``voltMeas1``) while keeping distinct
+        # unique_ids. Falls back to the JSON key for backward compatibility.
+        self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}_{unique_key or key}"
             
 
     @property

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -1,0 +1,80 @@
+"""Tests for multi-port (Grizzl-E Duo) field mapping.
+
+Regression tests for issue #23: the Duo reports its second cable through a
+different set of /main JSON keys than the naive ``curMeas2``/``voltMeas2``.
+"""
+import pytest
+
+from custom_components.grizzl_e.const import port_key
+
+
+# Real /main payloads captured from a Grizzl-E Duo (issue #23), trimmed to the
+# fields relevant to per-cable reporting.
+PORT1_CHARGING = {
+    "curMeas1": 22.17, "curMeas2": 0, "voltMeas1": 236, "voltMeas2": 0,
+    "powerMeas": 5234, "state": 4, "pilot": 2, "sessionStarted": 1,
+    "curMeas1C2": 0, "powerMeas2": 0, "state2": 2, "pilot2": 0, "sessionStarted2": 0,
+}
+PORT2_CHARGING = {
+    "curMeas1": 0, "curMeas2": 0, "voltMeas1": 236, "voltMeas2": 0,
+    "powerMeas": 0, "state": 2, "pilot": 0, "sessionStarted": 0,
+    "curMeas1C2": 22.39, "powerMeas2": 5286, "state2": 4, "pilot2": 2, "sessionStarted2": 1,
+}
+BOTH_CHARGING = {
+    "curMeas1": 20.52, "voltMeas1": 239, "powerMeas": 4905,
+    "curMeas1C2": 20.47, "powerMeas2": 4893,
+}
+
+
+def test_port1_keys_are_unchanged():
+    """Port 1 must keep the original keys (backward compatibility)."""
+    assert port_key("current", 1) == "curMeas1"
+    assert port_key("voltage", 1) == "voltMeas1"
+    assert port_key("power", 1) == "powerMeas"
+    assert port_key("state", 1) == "state"
+    assert port_key("pilot", 1) == "pilot"
+    assert port_key("session_started", 1) == "sessionStarted"
+
+
+def test_port2_uses_duo_specific_keys():
+    """Port 2 uses the Duo's non-standard keys (the bug in issue #23)."""
+    assert port_key("current", 2) == "curMeas1C2"   # NOT curMeas2 (always 0)
+    assert port_key("voltage", 2) == "voltMeas1"     # shared circuit, NOT voltMeas2
+    assert port_key("power", 2) == "powerMeas2"
+    assert port_key("state", 2) == "state2"
+    assert port_key("pilot", 2) == "pilot2"
+    assert port_key("session_started", 2) == "sessionStarted2"
+
+
+def test_port3_generalizes_pattern():
+    assert port_key("current", 3) == "curMeas1C3"
+    assert port_key("voltage", 3) == "voltMeas1"
+    assert port_key("power", 3) == "powerMeas3"
+
+
+@pytest.mark.parametrize(
+    "data, field, port, expected",
+    [
+        (PORT1_CHARGING, "current", 1, 22.17),
+        (PORT1_CHARGING, "power", 1, 5234),
+        (PORT1_CHARGING, "voltage", 2, 236),   # cable 2 shares cable 1 voltage
+        (PORT2_CHARGING, "current", 1, 0),
+        (PORT2_CHARGING, "current", 2, 22.39),  # would have been curMeas2 == 0
+        (PORT2_CHARGING, "voltage", 2, 236),    # would have been voltMeas2 == 0
+        (PORT2_CHARGING, "power", 2, 5286),
+        (PORT2_CHARGING, "state", 2, 4),
+        (PORT2_CHARGING, "session_started", 2, 1),
+        (BOTH_CHARGING, "current", 1, 20.52),
+        (BOTH_CHARGING, "current", 2, 20.47),
+        (BOTH_CHARGING, "power", 1, 4905),
+        (BOTH_CHARGING, "power", 2, 4893),
+    ],
+)
+def test_reading_through_port_key(data, field, port, expected):
+    assert data.get(port_key(field, port)) == expected
+
+
+def test_old_keys_were_always_zero_for_cable2():
+    """Documents why the old mapping failed: curMeas2/voltMeas2 stay 0."""
+    assert PORT2_CHARGING["curMeas2"] == 0
+    assert PORT2_CHARGING["voltMeas2"] == 0


### PR DESCRIPTION
Fixes #23.

## Problem

On the Grizzl-E **Duo**, selecting 2 ports produced a second port with no current/voltage/power. The integration assumed cable 2 lived in `curMeas2`/`voltMeas2`, but on the Duo those are **per-phase** fields that stay `0` on a single-phase unit. From the real `/main` payloads in #23, cable 2 is actually reported through:

- **current** → `curMeas1C2` (`curMeas2` is always 0)
- **voltage** → `voltMeas1` (both cables share one circuit, so voltage is only reported once)
- **power** → `powerMeas2`
- state/pilot/session → `state2`, `pilot2`, `sessionTime2`, `sessionEnergy2`, `sessionMoney2`, `totalEnergy2`, `sessionStarted2`

Separately, only Current/Voltage were ever created per-port; Power, Session/Total Energy, State, etc. were cable-1 only, so cable 2 had no power/energy tracking at all.

## Fix

- Add a `port_key(field, port)` helper in `const.py` that resolves each logical per-cable measurement to the correct JSON key for a given port (and generalizes the `curMeas1C{n}` pattern to a hypothetical 3rd cable).
- Make **all** per-cable sensors port-aware — Power, Current, Voltage, Session Energy, Total Energy, Session Time, Session Money, State, Pilot State — plus the binary sensors (Session Started, Pilot Connected).
- **Port 1 keeps its original entity `unique_id`s**, so existing single-port installs retain their history. Port 2+ get disambiguated ids (needed because both cables share `voltMeas1`).
- Enum sensors (State, Pilot State) no longer carry an invalid `measurement` state class.

## Tests

Added `tests/test_ports.py` with regression cases built from the exact Duo payloads posted in #23 (charging on cable 1 only, cable 2 only, and both at once).

## Verified

Confirmed working on a real Grizzl-E Duo (GRD 40A 2025, FW GRD077L-01.09.5): port 2 now reports live current, voltage, and power.

🤖 Generated with [Claude Code](https://claude.com/claude-code)